### PR TITLE
Bundle "ninja_syntax.py" into the wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,5 +155,6 @@ else()
 
 endif()
 
-install(PROGRAMS ${ninja_executable} DESTINATION bin)
+install(FILES ${Ninja_SOURCE_DIR}/misc/ninja_syntax.py DESTINATION ninja)
+install(PROGRAMS ${ninja_executable} DESTINATION ninja/data/bin)
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,8 @@ Ninja Python Distributions
 
 `Ninja <http://www.ninja-build.org>`_ is a small build system with a focus on speed.
 
-The Ninja python wheels provide `ninja 1.7.2 <https://ninja-build.org/manual.html>`_.
+The Ninja python wheels provide `ninja 1.7.2 <https://ninja-build.org/manual.html>`_ executable
+and `ninja_syntax.py` for generating .ninja files.
 
 This project is maintained by Jean-Christophe Fillion-Robin from Kitware Inc.
 It is covered by the `Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`_.

--- a/ninja/__init__.py
+++ b/ninja/__init__.py
@@ -7,6 +7,16 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+try:
+    from .ninja_syntax import Writer, escape, expand  # noqa: F401
+except ImportError:
+    # Support importing `ninja_syntax` from the source tree
+    if not os.path.exists(
+            os.path.join(os.path.dirname(__file__), 'ninja_syntax.py')):
+        sys.path.insert(0, os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '../src/misc')))
+    from ninja_syntax import Writer, escape, expand  # noqa: F401
+
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 # Support running tests from the source tree

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
 
     packages=['ninja'],
 
-    cmake_install_dir='ninja/data',
     cmake_with_sdist=True,
 
     entry_points={


### PR DESCRIPTION
To maintain backward compatibility with existing ninja wheels, this
commit includes "ninja_syntax.py".

Suggested-by: Marat Dukhan <maratek@gmail.com>