### PR TITLE
ci: Fix py33 and 34 build error ensuring all dependencies are up-to-date

### DIFF
--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -26,7 +26,7 @@ install:
   commands:
     - python --version
     - python -m pip install --disable-pip-version-check --upgrade pip
-    - $<RUN_ENV> pip install -r requirements-dev.txt
+    - $<RUN_ENV> pip install -U -r requirements-dev.txt
 
 before_build:
   commands:


### PR DESCRIPTION
Specifying -U ensures "setuptools>=28.0.0" required by scikit-build is
installed and fixes "cannot import name 'monkey'" error.