### PR TITLE
travis: Ensure MacOSX wheels can be installed on MacOSX >= 10.6

### DIFF
--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -19,6 +19,7 @@ before_install:
     osx:
       environment:
         PATH: $<HOME>/.pyenv/versions/$<PYTHON_VERSION>/bin:$<PATH>
+        SETUP_ARGS: --plat-name macosx-10.6-x86_64 -- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.6 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 -DCMAKE_OSX_SYSROOT:PATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
       commands:
         - python ../addons/travis/install_pyenv.py
 
@@ -35,7 +36,7 @@ before_build:
 build:
   commands:
     - python setup.py --hide-listing sdist
-    - $<RUN_ENV> python setup.py --hide-listing bdist_wheel
+    - $<RUN_ENV> python setup.py --hide-listing bdist_wheel $<SETUP_ARGS>
 
   circle:
     commands:


### PR DESCRIPTION
This is workaround waiting scikit-build/scikit-build#247 is addressed.

See https://github.com/MacPython/wiki/wiki/Spinning-wheels#question-will-pip-give-me-a-broken-wheel