### PR TITLE
Add pyproject.toml to ensure pip will download scikit-build when building from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build"]


### PR DESCRIPTION
Co-authored-by: Ondřej Čertík <ondrej@certik.us>