### PR TITLE
chore: use same `convert_to_generic_platform_wheel.py` script as cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ references:
             #
             export MANYLINUX_PYTHON=$(echo ${CIRCLE_JOB} | cut -d"_" -f2)
             echo "MANYLINUX_PYTHON [${MANYLINUX_PYTHON}]"
-            /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci
+            /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci -c constraints.txt
             /opt/python/${MANYLINUX_PYTHON}/bin/ci
       - persist_to_workspace:
           root: ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         python -m pip install --disable-pip-version-check --upgrade pip
-        pip install -U scikit-ci scikit-ci-addons
+        pip install -U scikit-ci scikit-ci-addons -c constraints.txt
         ci_addons --install ../addons
     fi
   - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
-  - "%PYTHON_DIR%\\python.exe -m pip install -U scikit-ci scikit-ci-addons"
+  - "%PYTHON_DIR%\\python.exe -m pip install -U scikit-ci scikit-ci-addons -c constraints.txt"
   - "%PYTHON_DIR%\\python.exe -m ci_addons --install ../addons"
 
   - ps: ../addons/appveyor/rolling-build.ps1

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+ruamel.yaml.clib==0.2.2
+ruamel.yaml==0.16.13

--- a/scripts/manylinux2014-aarch64-build-and-test-wheel.sh
+++ b/scripts/manylinux2014-aarch64-build-and-test-wheel.sh
@@ -9,7 +9,7 @@ export PATH="/opt/python/${MANYLINUX_PYTHON}/bin:$PATH"
 cd /io
 
 ci_before_install() {
-    /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci scikit-ci-addons scikit-build
+    /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci scikit-ci-addons scikit-build -c constraints.txt
 }
 
 ci_install() {


### PR DESCRIPTION
This prepares for `universal2` wheels and allows to create `py2.py3` wheels