### PR TITLE
chore: add nox and remove deprecated things

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,17 +60,16 @@ Get Started
 Ready to contribute? Here's how to set up `ninja-python-distributions` for local development.
 
 1. Fork the `ninja-python-distributions` repo on GitHub.
+
 2. Clone your fork locally::
 
     $ git clone git@github.com:your_name_here/ninja-python-distributions.git
 
-3. Install your local copy into a virtualenv. Assuming you have
-   virtualenvwrapper installed (`pip install virtualenvwrapper`), this is how
-   you set up your cloned fork for local development::
+3. Make sure you have ``nox`` installed (preferably use ``pipx`` or ``brew``
+   (macOS) if you have those)::
 
-    $ mkvirtualenv ninja-python-distributions
+    $ pip install nox
     $ cd ninja-python-distributions/
-    $ pip install -r requirements-dev.txt
 
 4. Create a branch for local development::
 
@@ -78,12 +77,10 @@ Ready to contribute? Here's how to set up `ninja-python-distributions` for local
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and
+5. When you're done making changes, check that your changes pass linters and
    the tests::
 
-    $ flake8
-    $ python setup.py bdist_wheel
-    $ python setup.py test
+    $ nox
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -115,6 +112,8 @@ Tips
 
 To run a subset of tests::
 
-	$ pytest tests/test_ninja.py
+    $ pytest tests/test_ninja.py
+    # OR
+    $ nox -s tests -- tests/test_ninja.py
 
 .. _GitHub Actions: https://github.com/scikit-build/ninja-python-distributions/actions/workflows/build.yml

--- a/docs/update_ninja_version.rst
+++ b/docs/update_ninja_version.rst
@@ -9,6 +9,19 @@ of Ninja associated with the current Ninja python distributions.
 
 Available Ninja archives can be found `here <https://github.com/kitware/ninja/releases>`_.
 
+Nox prodedure
+-------------
+
+If using nox, run::
+
+    nox -s bump -- <version>
+
+
+And follow the instructions it gives you. Leave off the version to bump to the latest version. Add `--commit` to run the commit procedure.
+
+Classic procedure:
+------------------
+
 1. Install `requests` and `githubrelease`::
 
     $ pip install requests githubrelease

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+import argparse
+from pathlib import Path
+
+import nox
+
+nox.options.sessions = ["lint", "build", "tests"]
+
+BUILD_ENV = {
+    "MACOSX_DEPLOYMENT_TARGET": "10.9",
+}
+
+
+built = ""
+
+
+@nox.session
+def build(session: nox.Session) -> str:
+    """
+    Make an SDist and a wheel. Only runs once.
+    """
+    global built
+    if not built:
+        session.log(
+            "The files produced locally by this job are not intended to be redistributable"
+        )
+        session.install("build")
+        tmpdir = session.create_tmp()
+        session.run("python", "-m", "build", "--outdir", tmpdir, env=BUILD_ENV)
+        (wheel_path,) = Path(tmpdir).glob("*.whl")
+        (sdist_path,) = Path(tmpdir).glob("*.tar.gz")
+        wheel_path.rename(f"dist/{wheel_path.name}")
+        sdist_path.rename(f"dist/{sdist_path.name}")
+        built = wheel_path.name
+    return built
+
+
+@nox.session
+def lint(session: nox.Session) -> str:
+    """
+    Run linters on the codebase.
+    """
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "-a")
+
+
+@nox.session
+def tests(session: nox.Session) -> str:
+    """
+    Run the tests.
+    """
+    wheel = build(session)
+    session.install(f"./dist/{wheel}[test]")
+    session.run("pytest", *session.posargs)
+
+
+@nox.session
+def bump(session: nox.Session) -> None:
+    """
+    Set to a new version, use -- <version>, otherwise will use the latest version.
+    """
+    parser = argparse.ArgumentParser(description="Process some integers.")
+    parser.add_argument(
+        "--commit", action="store_true", help="Make a branch and commit."
+    )
+    parser.add_argument(
+        "version", nargs="?", help="The version to process - leave off for latest."
+    )
+    args = parser.parse_args(session.posargs)
+
+    if args.version is None:
+        session.install("lastversion")
+        version = session.run(
+            "lastversion", "--format", "tag", "kitware/ninja", log=False, silent=True
+        ).strip()
+        if version.startswith("v"):
+            version = version[1:]
+    else:
+        version = args.version
+
+    session.install("githubrelease")
+
+    extra = ["--quiet"] if args.commit else []
+    session.run("python", "scripts/update_ninja_version.py", version, *extra)
+
+    if args.commit:
+        session.run("git", "switch", "-c", f"update-to-ninja-{version}", external=True)
+        files = (
+            "NinjaUrls.cmake",
+            "README.rst",
+            "tests/test_distribution.py",
+            "docs/update_ninja_version.rst",
+        )
+        session.run(
+            "git",
+            "add",
+            "-u",
+            *files,
+            external=True,
+        )
+        session.run("git", "commit", "-m", f"Update to Ninja {version}", external=True)
+        session.log(
+            'Complete! Now run: gh pr create --fill --body "Created by running `nox -s bump -- --commit`"'
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ before-all = [
 ]
 before-build = "pip install -r requirements-repair.txt"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
-test-requires = "-r requirements-test.txt"
+test-extras = "test"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.linux]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test = pytest
-
 [flake8]
 max-line-length: 120
 # Whether to display the pep8 instructions on failure (can be quite verbose)

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,6 @@ def parse_requirements(filename):
 requirements = []
 test_requirements = parse_requirements('requirements-test.txt')
 
-# Require pytest-runner only when running tests
-pytest_runner = (['pytest-runner>=2.0,<3dev']
-                 if any(arg in sys.argv for arg in ('pytest', 'test'))
-                 else [])
-
-setup_requires = pytest_runner
 
 setup(
     name='ninja',
@@ -78,7 +72,5 @@ setup(
 
     keywords='ninja build c++ fortran cross-platform cross-compilation',
 
-    install_requires=requirements,
-    tests_require=test_requirements,
-    setup_requires=setup_requires
+    extras_require={"test": test_requirements},
 )


### PR DESCRIPTION
This removes `test_requires` and `setup_requires`, as they are deprecated. This also adds nox, making it easier for new contributors to get started, as well as simplifying some tasks. Bumping to the latest version can now be done with `nox -s bump`!