### PR TITLE
Always build from sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,9 @@ jobs:
             arch: "ppc64le"
           - os: ubuntu-20.04
             arch: "s390x"
-          - os: windows-2019
+          - os: windows-2016
             arch: "AMD64"
-          - os: windows-2019
+          - os: windows-2016
             arch: "x86"
           - os: macos-10.15
             arch: "x86_64"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,8 @@ project(NinjaPythonDistributions)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_MODULE_PATH})
 
 # Options
-set(_build_from_source_default ON)
-if((WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8) OR APPLE)
-  set(_build_from_source_default OFF)
-endif()
-option(BUILD_FROM_SOURCE "Build Ninja from source" ${_build_from_source_default})
 option(BUILD_VERBOSE "Display additional information while building (e.g download progress, ...)" OFF)
 set(ARCHIVE_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}" CACHE PATH "Directory where to download archives")
-
-# Dependencies
-find_package(PythonInterp REQUIRED)
 
 include(NinjaUrls)
 
@@ -36,28 +28,12 @@ if(WIN32)
 endif()
 check_archive_var("${src_archive}")
 
-set(binary_archive "linux32_binary")
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(binary_archive "linux64_binary")
-endif()
-if(APPLE)
-  set(binary_archive "macosx_binary")
-endif()
-if(WIN32)
-  set(binary_archive "win32_binary")
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(binary_archive "win64_binary")
-  endif()
-endif()
-check_archive_var("${binary_archive}")
-
 #-----------------------------------------------------------------------------
 # Summary
 #-----------------------------------------------------------------------------
 message(STATUS "*********************************************")
 message(STATUS "Ninja Python Distribution")
 message(STATUS "")
-message(STATUS "  BUILD_FROM_SOURCE         : ${BUILD_FROM_SOURCE}")
 message(STATUS "  BUILD_VERBOSE             : ${BUILD_VERBOSE}")
 message(STATUS "")
 message(STATUS "  ARCHIVE_DOWNLOAD_DIR      : ${ARCHIVE_DOWNLOAD_DIR}")
@@ -65,10 +41,6 @@ message(STATUS "")
 message(STATUS "    src_archive             : ${src_archive}")
 message(STATUS "    <src_archive>_url       : ${${src_archive}_url}")
 message(STATUS "    <src_archive>_sha256    : ${${src_archive}_sha256}")
-message(STATUS "")
-message(STATUS "    binary_archive          : ${binary_archive}")
-message(STATUS "    <binary_archive>_url    : ${${binary_archive}_url}")
-message(STATUS "    <binary_archive>_sha256 : ${${binary_archive}_sha256}")
 message(STATUS "*********************************************")
 
 #-----------------------------------------------------------------------------
@@ -105,18 +77,21 @@ elseif(NOT EXISTS ${Ninja_SOURCE_DIR})
   message(FATAL_ERROR "Ninja_SOURCE_DIR is set to a nonexistent directory")
 endif()
 
-if(BUILD_FROM_SOURCE)
+#-----------------------------------------------------------------------------
+# Build from source
+#-----------------------------------------------------------------------------
+if(UNIX AND NOT APPLE)
+  # We're more likely to build from sources from PyPI on UNIX
+  # In order to relax the constraint on CMake version,
+  # use the python bootstrap script rather than the CMake build (requires 3.15+)
 
-  #-----------------------------------------------------------------------------
-  # Build from source
-  #-----------------------------------------------------------------------------
+  # Dependencies
+  find_package(PythonInterp REQUIRED)
+
   set(ninja_executable ${Ninja_SOURCE_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
-
   set(bootstrap_command ${PYTHON_EXECUTABLE} configure.py --bootstrap)
   # Explicitly defining _BSD_SOURCE is required to support building the wheel on Alpine. See issue  #22
-  if(UNIX AND NOT APPLE)
-    set(bootstrap_command ${CMAKE_COMMAND} -E env CXXFLAGS=-D_BSD_SOURCE ${bootstrap_command})
-  endif()
+  set(bootstrap_command ${CMAKE_COMMAND} -E env CXXFLAGS=-D_BSD_SOURCE ${bootstrap_command})
   add_custom_command(
     COMMAND ${bootstrap_command}
     OUTPUT ${ninja_executable}
@@ -125,41 +100,31 @@ if(BUILD_FROM_SOURCE)
   add_custom_target(build_ninja ALL
     DEPENDS download_ninja_source ${ninja_executable}
     )
-
-  find_program(STRIP_EXECUTABLE strip)
-  if(STRIP_EXECUTABLE)
-    add_custom_target(strip_ninja_executable ALL
-      COMMAND ${STRIP_EXECUTABLE} ${ninja_executable}
-      WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
-      COMMENT "Stripping ninja executable"
-      )
-    add_dependencies(strip_ninja_executable build_ninja)
-  endif()
-
 else()
-
-  #-----------------------------------------------------------------------------
-  # Download pre-built archive
-  #-----------------------------------------------------------------------------
-  if(${binary_archive}_sha256 STREQUAL "NA")
-    message(FATAL_ERROR "Pre-built archives not available for '${binary_archive}'. Consider setting BUILD_FROM_SOURCE to ON.")
-  endif()
-  # Download selected binary archive
-  ExternalProject_add(download_ninja_binary
-    SOURCE_DIR ${CMAKE_BINARY_DIR}/bin
-    URL ${${binary_archive}_url}
-    URL_HASH SHA256=${${binary_archive}_sha256}
-    DOWNLOAD_DIR ${ARCHIVE_DOWNLOAD_DIR}
-    USES_TERMINAL_DOWNLOAD 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    BUILD_IN_SOURCE 1
+  set(Ninja_BINARY_DIR ${CMAKE_BINARY_DIR}/Ninja-build)
+  ExternalProject_add(build_ninja
+    SOURCE_DIR ${Ninja_SOURCE_DIR}
+    BINARY_DIR ${Ninja_BINARY_DIR}
+    DOWNLOAD_COMMAND ""
+    UPDATE_COMMAND ""
+    BUILD_ALWAYS 1
+    USES_TERMINAL_CONFIGURE 1
+    USES_TERMINAL_BUILD 1
     INSTALL_COMMAND ""
-    ${ep_download_no_progress_args}
+    DEPENDS
+      download_ninja_source
     )
-  message(STATUS "download_ninja_binary - URL: ${${binary_archive}_url}")
-  set(ninja_executable ${CMAKE_BINARY_DIR}/bin/ninja${CMAKE_EXECUTABLE_SUFFIX})
+  set(ninja_executable ${Ninja_BINARY_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
+endif()
 
+find_program(STRIP_EXECUTABLE strip)
+if(STRIP_EXECUTABLE)
+  add_custom_target(strip_ninja_executable ALL
+    COMMAND ${STRIP_EXECUTABLE} ${ninja_executable}
+    WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
+    COMMENT "Stripping ninja executable"
+    )
+  add_dependencies(strip_ninja_executable build_ninja)
 endif()
 
 install(FILES ${Ninja_SOURCE_DIR}/misc/ninja_syntax.py DESTINATION src/ninja)

--- a/NinjaUrls.cmake
+++ b/NinjaUrls.cmake
@@ -1,25 +1,8 @@
 
 #-----------------------------------------------------------------------------
 # Ninja sources
-set(unix_source_url       "https://github.com/kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz")
+set(unix_source_url       "https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz")
 set(unix_source_sha256    "d00033813993116a4e14f835df813daee9916b107333d88dbb798a22f8671b1f")
 
-set(windows_source_url    "https://github.com/kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.zip")
+set(windows_source_url    "https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.zip")
 set(windows_source_sha256 "8399607087a165436e6bb35beed7c235180ba4a9af608f8c19bc5812ced06a81")
-
-#-----------------------------------------------------------------------------
-# Ninja binaries
-set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
-set(linux32_binary_sha256 "NA")
-
-set(linux64_binary_url    "https://github.com/Kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1_x86_64-linux-gnu.tar.gz")
-set(linux64_binary_sha256 "5bb10ae9df47489b0e77732ed9fd95acccdd211d01fb6b26130fd408515b8995")
-
-set(macosx_binary_url    "https://github.com/Kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1_x86_64-apple-darwin.tar.gz")
-set(macosx_binary_sha256 "4acd065772228a5dd4cf85428b304cc157f07c333e4ea9931978eaef59f5e313")
-
-set(win32_binary_url    "NA")  # Windows 32-bit binaries not available
-set(win32_binary_sha256 "NA")
-
-set(win64_binary_url    "https://github.com/Kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1_i686-pc-windows-msvc.zip")
-set(win64_binary_sha256 "7f54cd8d72306b14bcb3518e21bc0c5f9d8ec31dea7ccd340cbfade070e30019")

--- a/docs/update_ninja_version.rst
+++ b/docs/update_ninja_version.rst
@@ -7,7 +7,7 @@ Updating the Ninja version
 A developer should use the following steps to update the version ``X.Y.Z``
 of Ninja associated with the current Ninja python distributions.
 
-Available Ninja archives can be found `here <https://github.com/kitware/ninja/releases>`_.
+Available Ninja archives can be found `here <https://github.com/Kitware/ninja/releases>`_.
 
 Nox prodedure
 -------------
@@ -32,18 +32,12 @@ Classic procedure:
     $ release=1.10.0.gfb670.kitware.jobserver-1
     $ python scripts/update_ninja_version.py ${release}
 
-    Collecting URLs and SHA256s from 'https://github.com/kitware/ninja/releases'
-    Downloading https://github.com/kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz
-    Downloading https://github.com/kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz - done
-    Downloading https://github.com/kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.zip
-    Downloading https://github.com/kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.zip - done
-    Downloading https://github.com/kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1
-    Downloading https://github.com/kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1 - done
-    Downloading https://github.com/kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1
-    Downloading https://github.com/kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1 - done
-    Downloading https://github.com/kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1
-    Downloading https://github.com/kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1 - done
-    Collecting URLs and SHA256s from 'https://github.com/kitware/ninja/releases' - done
+    Collecting URLs and SHA256s from 'https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1'
+    Downloading https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz
+    Downloading https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz - done
+    Downloading https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.zip
+    Downloading https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.zip - done
+    Collecting URLs and SHA256s from 'https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1' - done
     Updating 'NinjaUrls.cmake' with CMake version 1.10.0.gfb670.kitware.jobserver-1
     Updating 'NinjaUrls.cmake' with CMake version 1.10.0.gfb670.kitware.jobserver-1 - done
     Updating README.rst

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,6 +62,13 @@ def bump(session: nox.Session) -> None:
     """
     parser = argparse.ArgumentParser(description="Process some integers.")
     parser.add_argument(
+        "--upstream-repository",
+        metavar="UPSTREAM_REPOSITORY",
+        choices=["Kitware/ninja", "ninja-build/ninja"],
+        default="Kitware/ninja",
+        help="Ninja upstream repository",
+    )
+    parser.add_argument(
         "--commit", action="store_true", help="Make a branch and commit."
     )
     parser.add_argument(
@@ -72,17 +79,17 @@ def bump(session: nox.Session) -> None:
     if args.version is None:
         session.install("lastversion")
         version = session.run(
-            "lastversion", "--format", "tag", "kitware/ninja", log=False, silent=True
+            "lastversion", "--format", "tag", args.upstream_repository, log=False, silent=True
         ).strip()
         if version.startswith("v"):
             version = version[1:]
     else:
         version = args.version
 
-    session.install("githubrelease")
+    session.install("requests")
 
     extra = ["--quiet"] if args.commit else []
-    session.run("python", "scripts/update_ninja_version.py", version, *extra)
+    session.run("python", "scripts/update_ninja_version.py", "--upstream-repository", args.upstream_repository, version, *extra)
 
     if args.commit:
         session.run("git", "switch", "-c", f"update-to-ninja-{version}", external=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length: 120
+max-line-length: 130
 # Whether to display the pep8 instructions on failure (can be quite verbose)
 show-pep8: False
 # Whether to show source code for each failure
@@ -7,7 +7,7 @@ show-source: True
 # Maximum cyclomatic complexity allowed
 max-complexity: 14
 format: pylint
-exclude: .git,.idea,.eggs,__pycache__,.tox,_skbuild,Ninja-src,src,versioneer.py,ninja/ninja_syntax.py,_version.py
+exclude: .git,.idea,.eggs,__pycache__,.tox,_skbuild,Ninja-src,src,versioneer.py,ninja/ninja_syntax.py,_version.py,.venv,.nox
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
This helps not to depend on upstream builds given we were already building almost all from sources with the exception of macOS build and Windows x86_64 build.

see also #41