### PR TITLE
fix(ci): test_sdist shall not test wheels installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,12 +98,12 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: dist
+          path: sdist
 
       - name: Install SDist
         env:
           SKBUILD_CONFIGURE_OPTIONS: "-DBUILD_CMAKE_FROM_SOURCE:BOOL=OFF"
-        run: pip install dist/*.tar.gz
+        run: pip install sdist/*.tar.gz
 
       - name: Install test dependencies
         run: pip install -r requirements-test.txt


### PR DESCRIPTION
There's a race condition in the jobs meaning `dist` will be populated by the the sdist and any number of wheels. If there's more than one wheel, sdist tests will fail.
We do not require tests in test_distribution.py which are meant for local builds.
Rather than excluding these tests, simply do not provide a `dist` folder to look at. It keeps the workflow simple and if anyone tries to reproduce locally they will run these tests which are meant to be run locally.