### PR TITLE
chore(ci): use cibuildwheel 2.2.0a1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.2.0a1
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
 


### PR DESCRIPTION
This now builds musllinux wheels.