### PR TITLE
fix: non-isolated build fails when versioneer is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ from skbuild import setup
 
 # Add current folder to path
 # This is required to import versioneer in an isolated pip build
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+# Prepending allows not to break on a non-isolated build when versioneer
+# is already installed (c.f. https://github.com/scikit-build/cmake-python-distributions/issues/171)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import versioneer  # noqa: E402
 


### PR DESCRIPTION
Identical fix to https://github.com/scikit-build/cmake-python-distributions/pull/175
I've noticed that piwheels is unable to build ninja wheels due to the same problem that was reported for cmake in https://github.com/scikit-build/cmake-python-distributions/issues/171 