### PR TITLE
Add project URLs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,12 @@ setup(
 
     url=r'http://ninja-build.org/',
     download_url=r'https://github.com/ninja-build/ninja/releases',
+    project_urls={
+        "Documentation": "https://github.com/scikit-build/ninja-python-distributions#readme",
+        "Source Code": "https://github.com/scikit-build/ninja-python-distributions",
+        "Mailing list": "https://groups.google.com/forum/#!forum/scikit-build",
+        "Bug Tracker": "https://github.com/scikit-build/ninja-python-distributions/issues",
+    },
 
     description=r'Ninja is a small build system with a focus on speed',
 


### PR DESCRIPTION
This makes it easier to navigate to the source of the actual PyPI project rather than the ninja project itself. I personally often use the project URLs in the sidebar and find it helpful to be able to go to the actual source of the package for one reason or another. Similar to: https://github.com/scikit-build/cmake-python-distributions/pull/133