### PR TITLE
Support OS400 system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,26 +88,14 @@ if(UNIX AND NOT APPLE)
   # Dependencies
   find_package(PythonInterp REQUIRED)
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
-    #configure.py is deprecated by ninja-build project. And it does support OS400.
-    set(ninja_executable ${Ninja_SOURCE_DIR}/cmake-build/ninja${CMAKE_EXECUTABLE_SUFFIX})
-    set(local_cmake_command ${CMAKE_COMMAND} -Bcmake-build -H. && ${CMAKE_COMMAND} --build cmake-build)
-    add_custom_command(
-      COMMAND ${local_cmake_command}
-      OUTPUT ${ninja_executable}
-      WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
-      )
-  else()
-    set(ninja_executable ${Ninja_SOURCE_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
-    set(bootstrap_command ${PYTHON_EXECUTABLE} configure.py --bootstrap)
-    # Explicitly defining _BSD_SOURCE is required to support building the wheel on Alpine. See issue  #22
-    set(bootstrap_command ${CMAKE_COMMAND} -E env CXXFLAGS=-D_BSD_SOURCE ${bootstrap_command})
-    add_custom_command(
-      COMMAND ${bootstrap_command}
-      OUTPUT ${ninja_executable}
-      WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
-      )
-  endif()
+  #configure.py is deprecated by ninja-build project. 
+  set(ninja_executable ${Ninja_SOURCE_DIR}/cmake-build/ninja${CMAKE_EXECUTABLE_SUFFIX})
+  set(local_cmake_command ${CMAKE_COMMAND} -Bcmake-build -H. && ${CMAKE_COMMAND} --build cmake-build)
+  add_custom_command(
+    COMMAND ${local_cmake_command}
+    OUTPUT ${ninja_executable}
+    WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
+    )
   add_custom_target(build_ninja ALL
     DEPENDS download_ninja_source ${ninja_executable}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if(UNIX AND NOT APPLE)
   # Dependencies
   find_package(PythonInterp REQUIRED)
 
-  #configure.py is deprecated by ninja-build project. 
+  #configure.py is deprecated by ninja-build project.
   set(ninja_executable ${Ninja_SOURCE_DIR}/cmake-build/ninja${CMAKE_EXECUTABLE_SUFFIX})
   set(local_cmake_command ${CMAKE_COMMAND} -Bcmake-build -H. && ${CMAKE_COMMAND} --build cmake-build)
   add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,15 +88,26 @@ if(UNIX AND NOT APPLE)
   # Dependencies
   find_package(PythonInterp REQUIRED)
 
-  set(ninja_executable ${Ninja_SOURCE_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
-  set(bootstrap_command ${PYTHON_EXECUTABLE} configure.py --bootstrap)
-  # Explicitly defining _BSD_SOURCE is required to support building the wheel on Alpine. See issue  #22
-  set(bootstrap_command ${CMAKE_COMMAND} -E env CXXFLAGS=-D_BSD_SOURCE ${bootstrap_command})
-  add_custom_command(
-    COMMAND ${bootstrap_command}
-    OUTPUT ${ninja_executable}
-    WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
-    )
+  if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
+    #configure.py is deprecated by ninja-build project. And it does support OS400.
+    set(ninja_executable ${Ninja_SOURCE_DIR}/cmake-build/ninja${CMAKE_EXECUTABLE_SUFFIX})
+    set(local_cmake_command ${CMAKE_COMMAND} -Bcmake-build -H. && ${CMAKE_COMMAND} --build cmake-build)
+    add_custom_command(
+      COMMAND ${local_cmake_command}
+      OUTPUT ${ninja_executable}
+      WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
+      )
+  else()
+    set(ninja_executable ${Ninja_SOURCE_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
+    set(bootstrap_command ${PYTHON_EXECUTABLE} configure.py --bootstrap)
+    # Explicitly defining _BSD_SOURCE is required to support building the wheel on Alpine. See issue  #22
+    set(bootstrap_command ${CMAKE_COMMAND} -E env CXXFLAGS=-D_BSD_SOURCE ${bootstrap_command})
+    add_custom_command(
+      COMMAND ${bootstrap_command}
+      OUTPUT ${ninja_executable}
+      WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
+      )
+  endif()
   add_custom_target(build_ninja ALL
     DEPENDS download_ninja_source ${ninja_executable}
     )


### PR DESCRIPTION
This PR is for OS400 system support. Can anybody kindly help to review and merge it? thanks. 
"configure.py" is deprecated in ninja-build project, and it does not support OS400 system. 