### PR TITLE
fix: missing delimiter in trove classifiers definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,9 @@ setup(
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools'
+        'Topic :: Software Development :: Build Tools',
         'Typing :: Typed',
-        ],
+    ],
 
     license='Apache 2.0',
 


### PR DESCRIPTION
Issue found doing a diff between PyPI wheels and wheels in #139 