### PR TITLE
chore: run ninja test suite as part of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.15)
 
 project(NinjaPythonDistributions)
 
@@ -6,6 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_MODULE_PATH})
 
 # Options
 option(BUILD_VERBOSE "Display additional information while building (e.g download progress, ...)" OFF)
+option(RUN_NINJA_TEST "Run Ninja test suite" ON)
 set(ARCHIVE_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}" CACHE PATH "Directory where to download archives")
 
 include(NinjaUrls)
@@ -35,6 +36,7 @@ message(STATUS "*********************************************")
 message(STATUS "Ninja Python Distribution")
 message(STATUS "")
 message(STATUS "  BUILD_VERBOSE             : ${BUILD_VERBOSE}")
+message(STATUS "  RUN_NINJA_TEST            : ${RUN_NINJA_TEST}")
 message(STATUS "")
 message(STATUS "  ARCHIVE_DOWNLOAD_DIR      : ${ARCHIVE_DOWNLOAD_DIR}")
 message(STATUS "")
@@ -80,75 +82,64 @@ endif()
 #-----------------------------------------------------------------------------
 # Build from source
 #-----------------------------------------------------------------------------
-if(UNIX AND NOT APPLE)
-  # We're more likely to build from sources from PyPI on UNIX
-  # In order to relax the constraint on CMake version,
-  # use the python bootstrap script rather than the CMake build (requires 3.15+)
+set(Ninja_BINARY_DIR ${CMAKE_BINARY_DIR}/Ninja-build)
+# cache arguments
+set(_cache_args )
+foreach(var_name IN ITEMS
+  CMAKE_BUILD_TYPE
+  CMAKE_TOOLCHAIN_FILE
+  CMAKE_BUILD_PARALLEL_LEVEL
+  CMAKE_JOB_POOLS
+  CMAKE_JOB_POOL_COMPILE
+  CMAKE_JOB_POOL_LINK
+  CMAKE_OSX_DEPLOYMENT_TARGET
+  CMAKE_OSX_ARCHITECTURES
+  CMAKE_OSX_SYSROOT
+  )
+  if(DEFINED ${var_name})
+    list(APPEND _cache_args -D${var_name}:STRING=${${var_name}})
+    message(STATUS "SuperBuild - ${var_name}: ${${var_name}}")
+  endif()
+endforeach()
 
-  # Dependencies
-  find_package(PythonInterp REQUIRED)
-
-  #configure.py is deprecated by ninja-build project.
-  set(ninja_executable ${Ninja_SOURCE_DIR}/cmake-build/ninja${CMAKE_EXECUTABLE_SUFFIX})
-  set(local_cmake_command ${CMAKE_COMMAND} -Bcmake-build -H. && ${CMAKE_COMMAND} --build cmake-build)
-  add_custom_command(
-    COMMAND ${local_cmake_command}
-    OUTPUT ${ninja_executable}
-    WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
-    )
-  add_custom_target(build_ninja ALL
-    DEPENDS download_ninja_source ${ninja_executable}
-    )
-else()
-  set(Ninja_BINARY_DIR ${CMAKE_BINARY_DIR}/Ninja-build)
-  # cache arguments
-  set(_cache_args )
-  foreach(var_name IN ITEMS
-    CMAKE_BUILD_TYPE
-    CMAKE_TOOLCHAIN_FILE
-    CMAKE_BUILD_PARALLEL_LEVEL
-    CMAKE_JOB_POOLS
-    CMAKE_JOB_POOL_COMPILE
-    CMAKE_JOB_POOL_LINK
-    CMAKE_OSX_DEPLOYMENT_TARGET
-    CMAKE_OSX_ARCHITECTURES
-    CMAKE_OSX_SYSROOT
-    )
-    if(DEFINED ${var_name})
-      list(APPEND _cache_args
-        -D${var_name}:STRING=${${var_name}}
-        )
-      message(STATUS "SuperBuild - ${var_name}: ${${var_name}}")
-    endif()
-  endforeach()
-  # _cache_args should not be empty
-  list(APPEND _cache_args
-    -DNINJA_SUPERBUILD:BOOL=true
-    )
-  ExternalProject_add(build_ninja
-    SOURCE_DIR ${Ninja_SOURCE_DIR}
-    BINARY_DIR ${Ninja_BINARY_DIR}
-    DOWNLOAD_COMMAND ""
-    UPDATE_COMMAND ""
-    BUILD_ALWAYS 1
-    USES_TERMINAL_CONFIGURE 1
-    USES_TERMINAL_BUILD 1
-    INSTALL_COMMAND ""
-    CMAKE_CACHE_ARGS ${_cache_args}
-    DEPENDS
-      download_ninja_source
-    )
-  set(ninja_executable ${Ninja_BINARY_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
-endif()
+# _cache_args should not be empty
+list(APPEND _cache_args -DNINJA_SUPERBUILD:BOOL=true)
+ExternalProject_add(build_ninja
+  SOURCE_DIR ${Ninja_SOURCE_DIR}
+  BINARY_DIR ${Ninja_BINARY_DIR}
+  DOWNLOAD_COMMAND ""
+  UPDATE_COMMAND ""
+  BUILD_ALWAYS 1
+  USES_TERMINAL_CONFIGURE 1
+  USES_TERMINAL_BUILD 1
+  INSTALL_COMMAND ""
+  CMAKE_CACHE_ARGS ${_cache_args}
+  DEPENDS
+    download_ninja_source
+  )
+set(ninja_executable ${Ninja_BINARY_DIR}/ninja${CMAKE_EXECUTABLE_SUFFIX})
+set(NINJA_BUILD_LAST_STEP "build")
 
 find_program(STRIP_EXECUTABLE strip)
 if(STRIP_EXECUTABLE)
-  add_custom_target(strip_ninja_executable ALL
+  ExternalProject_Add_Step(build_ninja strip_executables
+    DEPENDEES ${NINJA_BUILD_LAST_STEP}
+    COMMENT "Stripping CMake executables"
     COMMAND ${STRIP_EXECUTABLE} ${ninja_executable}
-    WORKING_DIRECTORY ${Ninja_SOURCE_DIR}
-    COMMENT "Stripping ninja executable"
+    USES_TERMINAL 1
     )
-  add_dependencies(strip_ninja_executable build_ninja)
+  set(NINJA_BUILD_LAST_STEP "strip_executables")
+endif()
+
+if(RUN_NINJA_TEST)
+  ExternalProject_Add_Step(build_ninja run_ninja_test_suite
+    DEPENDEES ${NINJA_BUILD_LAST_STEP}
+    COMMENT "Running Ninja test suite"
+    COMMAND ${Ninja_BINARY_DIR}/ninja_test${CMAKE_EXECUTABLE_SUFFIX}
+    WORKING_DIRECTORY ${Ninja_BINARY_DIR}
+    USES_TERMINAL 1
+    )
+  set(NINJA_BUILD_LAST_STEP "run_ninja_test_suite")
 endif()
 
 install(FILES ${Ninja_SOURCE_DIR}/misc/ninja_syntax.py DESTINATION src/ninja)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp39-*"
+build-verbosity = 1
 before-all = [
     'pipx install -f --pip-args="-c {project}/constraints-ci.txt" cmake',
     'cmake --version',


### PR DESCRIPTION
Following https://github.com/scikit-build/ninja-python-distributions/pull/139#pullrequestreview-1111419421, run Ninja test suite as part of the build

In #139 review, I focused on the diff only. With the full picture when adding tests, it seems that we can follow the same build workflow for Linux & macOS/Windows.
#139 effectively bumped the minimum CMake version to 3.15 (the one required by Ninja itself), so this was bumped here as well.