### PR TITLE
fix: allow access to file descriptors

### DIFF
--- a/src/ninja/__init__.py
+++ b/src/ninja/__init__.py
@@ -44,7 +44,7 @@ BIN_DIR = os.path.join(DATA, 'bin')
 
 
 def _program(name, args):
-    return subprocess.call([os.path.join(BIN_DIR, name)] + args)
+    return subprocess.call([os.path.join(BIN_DIR, name)] + args, close_fds=False)
 
 
 def ninja():


### PR DESCRIPTION
This is needed for things like jobserver support using the installed "ninja" shortcut. Which is why this is a fork in the first place... See scikit-build/cmake-python-distributions#290.