### PR TITLE
fix: bump to manylinux 2010, add test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,13 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+      - name: Test wheel on host Linux
+        if: runner.os == 'Linux' && matrix.arch == 'x86_64'
+        run: |
+          pip install wheelhouse/*manylinux*x86_64*.whl
+          ninja --version
+          python -m ninja --version
+
   build_sdist:
     name: Build source distribution
     needs: [lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ test-extras = "test"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux1"
-manylinux-i686-image = "manylinux1"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"
 
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.9"


### PR DESCRIPTION
From #157. I've uploaded manually built 1.11.1 binaries for manylinux2010. This adds a test that shows the breakage, then adds the bump to 2010 which fixes it. Should we also ship manylinux1? I'd say no (in fact, I think I'd be fine to delete the old manylinux1 binaries for 1.11.1) - it's probably more likely that and old pip would get a broken binary than someone would need this on actual manylinux1.

I'd like to know why this broke - was is ninja, or is there some issue with the latest manylinux1? Maybe someone will investigate someday. 

FYI, to build locally with a different manylinux, say for the 32-bit wheel:

```python
git checkout 1.11.1
CIBW_MANYLINUX_I686_IMAGE=manylinux2010 pipx run cibuildwheel --only cp39-manylinux_i686
```