### PR TITLE
fix(wheels): link libstdc++ statically on manylinux1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,13 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+      - name: Test wheel on host Linux
+        if: runner.os == 'Linux' && matrix.arch == 'x86_64'
+        run: |
+          pip install wheelhouse/*manylinux*x86_64*.whl
+          ninja --version
+          python -m ninja --version
+
   build_sdist:
     name: Build source distribution
     needs: [lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,11 @@ repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-extras = "test"
 test-command = "pytest {project}/tests"
 
-[tool.cibuildwheel.linux]
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_{x86_64,i686}"
 manylinux-x86_64-image = "manylinux1"
 manylinux-i686-image = "manylinux1"
+environment = { LDFLAGS = "-static-libstdc++" }
 
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.9"


### PR DESCRIPTION
For some reason, the ninja binary built on manylinux1 is segfaulting on ubuntu20.04+ & RHEL 8+. Statically linking libstdc++ fixes the issue.

fixes #157 