### PR TITLE
chore(wheels): link libstdc++/libgcc statically on musllinux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,9 @@ before-all = [
     'ninja --version',
 ]
 
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux_*"
+environment = { LDFLAGS = "-static-libstdc++ -static-libgcc" }
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This reduces the size of the wheels & installed binaries on musllinux.