### PR TITLE
chore: use trusted publisher deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,4 +162,4 @@ jobs:
           path: dist
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v4
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,11 @@ jobs:
     needs: [check_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'scikit-build/ninja-python-distributions' && startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ninja
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -157,7 +162,4 @@ jobs:
           path: dist
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_RELEASE_PASSWORD }}
+        uses: pypa/gh-action-pypi-publish@release/v4


### PR DESCRIPTION
Change adapted from:
* https://github.com/scikit-build/cmake-python-distributions/pull/366

Corresponding publisher also added on `PyPI`

![image](https://github.com/scikit-build/ninja-python-distributions/assets/219043/ca05d366-8169-4bd9-948f-0e61d5885e92)
