### PR TITLE
chore: continue testing with python 2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         name: Install Python ${{ matrix.python }}
+        if: matrix.python != '2.7'
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Install Ubuntu Python 2.7
+        if: matrix.python == '2.7'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python2 python3-virtualenv
+          virtualenv -p python2 ${HOME}/cp27
+          ${HOME}/cp27/bin/python -m pip install -U pip
+          ${HOME}/cp27/bin/python -m pip install -U setuptools wheel
+          echo "${HOME}/cp27/bin" >> $GITHUB_PATH
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
`actions/setup-python` [removed python 2.7](https://github.com/actions/setup-python/issues/672) in all versions of the action.
Use Ubuntu provided python 2.7 to continue testing.

PS: I don't mind dropping python2.7 to build ninja wheel but, IMHO, as long as the wheel is built with python 2 compatibility we should at least test the wheel with python 2.7