### PR TITLE
chore: remove `versioneer` related code from `setup.py`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ include LICENSE_Apache_20
 recursive-exclude _skbuild *
 recursive-exclude Ninja-src *
 
-include versioneer.py
 include src/ninja/_version.py
+include src/ninja/_version.pyi
 include src/ninja/__init__.pyi
 include src/ninja/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ unfixable = [
   "T20",  # Removes print statements
   "F841", # Removes unused variables
 ]
-exclude = ["versioneer.py", "src/ninja/version.py"]
+exclude = ["src/ninja/version.py"]
 flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.per-file-ignores]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
 [tool:pytest]
 testpaths = tests
 addopts = -v --cov --cov-report xml
-
-[versioneer]
-VCS = git
-versionfile_source = src/ninja/_version.py
-versionfile_build = ninja/_version.py
-style = pep440-post
-tag_prefix = ''

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-import sys
 from distutils.text_file import TextFile
 
 from skbuild import setup
-
-# Add current folder to path
-# This is required to import versioneer in an isolated pip build
-# Prepending allows not to break on a non-isolated build when versioneer
-# is already installed (c.f. https://github.com/scikit-build/cmake-python-distributions/issues/171)
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 with open('README.rst', 'r') as fp:
     readme = fp.read()


### PR DESCRIPTION
`versioneer` was removed in https://github.com/scikit-build/ninja-python-distributions/pull/170