### PR TITLE
fix: build from sources with `--no-binary=ninja`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,8 +128,11 @@ jobs:
           name: cibw-sdist
           path: sdist
 
+      - name: Ensure Ninja not present on the system
+        run: if which ninja; then false; fi
+
       - name: Install SDist
-        run: pip install $(ls sdist/*.tar.gz)[test] -Ccmake.define.BUILD_CMAKE_FROM_SOURCE=OFF
+        run: pip install --no-binary=ninja $(ls sdist/*.tar.gz)[test] -Ccmake.define.BUILD_CMAKE_FROM_SOURCE=OFF
 
       - name: Test installed SDist
         run: pip check && pytest ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         run: if which ninja; then false; fi
 
       - name: Install SDist
-        run: pip install --no-binary=ninja $(ls sdist/*.tar.gz)[test] -Ccmake.define.BUILD_CMAKE_FROM_SOURCE=OFF
+        run: pip install --no-binary=ninja $(ls sdist/*.tar.gz)[test]
 
       - name: Test installed SDist
         run: pip check && pytest ./tests

--- a/_build_backend/backend.py
+++ b/_build_backend/backend.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+from scikit_build_core import build as _orig
+
+if hasattr(_orig, "prepare_metadata_for_build_editable"):
+    prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable
+if hasattr(_orig, "prepare_metadata_for_build_wheel"):
+    prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+build_editable = _orig.build_editable
+build_wheel = _orig.build_wheel
+build_sdist = _orig.build_sdist
+get_requires_for_build_editable = _orig.get_requires_for_build_editable
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+
+def get_requires_for_build_wheel(config_settings=None):
+    packages_orig = _orig.get_requires_for_build_wheel(config_settings)
+    if os.environ.get("NINJA_PYTHON_DIST_ALLOW_NINJA_DEP", "0") != "0":
+        return packages_orig
+    packages = []
+    for package in packages_orig:
+        package_name = package.lower().split(">")[0].strip()
+        if package_name == "ninja":
+            # never request ninja from the ninja build
+            continue
+        packages.append(package)
+    return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ Homepage = "http://ninja-build.org/"
 
 [tool.scikit-build]
 minimum-version = "build-system.requires"
+cmake.version = "CMakeLists.txt"  # Force parsing version from CMakeLists.txt and disable fallback to '>=3.15'
 ninja.make-fallback = true
 build-dir = "build/{wheel_tag}"
 wheel.py-api = "py3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-requires = ["scikit-build-core"]
-build-backend = "scikit_build_core.build"
+requires = ["scikit-build-core>=0.10"]
+build-backend = "backend"
+backend-path = ["_build_backend"]
 
 [project]
 name = "ninja"
@@ -50,7 +51,8 @@ Homepage = "http://ninja-build.org/"
 "Source Code" = "https://github.com/scikit-build/ninja-python-distributions"
 
 [tool.scikit-build]
-minimum-version = "0.9"
+minimum-version = "build-system.requires"
+ninja.make-fallback = true
 build-dir = "build/{wheel_tag}"
 wheel.py-api = "py3"
 wheel.expand-macos-universal-tags = true
@@ -88,6 +90,7 @@ build-verbosity = 1
 test-extras = "test"
 test-command = "pytest {project}/tests"
 test-skip = ["*-win_arm64", "*-macosx_universal2:arm64"]
+environment = { NINJA_PYTHON_DIST_ALLOW_NINJA_DEP = "1" }
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 musllinux-x86_64-image = "musllinux_1_1"
 musllinux-i686-image = "musllinux_1_1"
@@ -96,20 +99,24 @@ musllinux-ppc64le-image = "musllinux_1_1"
 musllinux-s390x-image = "musllinux_1_1"
 musllinux-armv7l-image = "musllinux_1_2"
 
-[tool.cibuildwheel.macos.environment]
-MACOSX_DEPLOYMENT_TARGET = "10.9"
+[[tool.cibuildwheel.overrides]]
+select = "*-macos*"
+inherit.environment = "append"
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.9" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-manylinux_{x86_64,i686}"
 manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
 build-frontend = "pip"
+inherit.environment = "append"
 environment = { LDFLAGS = "-static-libstdc++" }
 inherit.test-command = "prepend"
 test-command = "pip check"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux_*"
+inherit.environment = "append"
 environment = { LDFLAGS = "-static-libstdc++ -static-libgcc" }
 
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
fix #274 

Ninja shall never request ninja in its build dependencies as a default behavior.

When scikit-build-core knows a ninja binary wheel exists for a given platform, it's always added as a dependency when a valid one is not found on the system.

Let's allow ninja to depend on ninja only if explicitly allowed (this will speed-up the CI here). In other cases, it's more likely that a request to build ninja would be because of a forced source only build.
