### PR TITLE
fix: linter issues & nox macOS build

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-branch = True
-include = ninja/*.py
-omit = ninja/_version.py
-
-[xml]
-output = tests/coverage.xml

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,9 +13,7 @@ nox.options.sessions = ["lint", "build", "tests"]
 if sys.platform.startswith("darwin"):
     BUILD_ENV = {
         "MACOSX_DEPLOYMENT_TARGET": "10.9",
-        "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64",
-        "CFLAGS": "-save-temps",
-        "CXXFLAGS": "-save-temps",
+        "ARCHFLAGS": "-arch arm64 -arch x86_64",
     }
 else:
     BUILD_ENV = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,7 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 test = [
-    "coverage>=4.2",
     "importlib_metadata>=2.0",
-    "pytest-cov>=3",
     "pytest>=6.0",
 ]
 
@@ -129,10 +127,10 @@ test-command = "pip check"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--strict-markers", "--strict-config", "-v"]
 xfail_strict = true
 filterwarnings = ["error"]
-log_cli_level = "info"
+log_cli_level = "INFO"
 testpaths = [ "tests" ]
 
 
@@ -178,7 +176,3 @@ flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.lint.per-file-ignores]
 "*.pyi" = ["ARG001"]
-
-[tool.pytest.ini_config]
-testpaths = ["tests"]
-addopts = ["-v", "--cov", "--cov-report", "xml"]


### PR DESCRIPTION
- fix: remove unused options from pytest
  coverage is removed altogether as it's not working
  this fixes the linter issue.
- fix: macOS build using nox
  With the move from scikit-build to scikit-build-core, the macOS build options need to be updated.