### PR TITLE
chore: Simplify build-system replacing FetchContent calls with add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,7 @@ message(STATUS "")
 message(STATUS "  RUN_NINJA_TEST : ${RUN_NINJA_TEST}")
 message(STATUS "************************************")
 
-include(FetchContent)
-FetchContent_Declare(
-  ninja
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ninja-upstream
-)
-FetchContent_MakeAvailable(ninja)
+add_subdirectory(ninja-upstream)
 
 if(RUN_NINJA_TEST)
   add_custom_target(


### PR DESCRIPTION
Following 7a70669 ("feat: use a submodule for ninja sources (#278)", 2025-03-20), attempting to fetch sources is not required as sources are already expected to be available.