### PR TITLE
feat: use 1.13.0 from Kitware fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ninja-upstream"]
 	path = ninja-upstream
-	url = https://github.com/ninja-build/ninja.git
+	url = https://github.com/Kitware/ninja.git

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Ninja Python Distributions
 
 `Ninja <http://www.ninja-build.org>`_ is a small build system with a focus on speed.
 
-The latest Ninja python wheels provide `ninja 1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1 <https://ninja-build.org/manual.html>`_ executable
+The latest Ninja python wheels provide `ninja 1.13.0.gd74ef.kitware.jobserver-pipe-1 <https://ninja-build.org/manual.html>`_ executable
 and `ninja_syntax.py` for generating `.ninja` files.
 
 .. image:: https://raw.githubusercontent.com/scikit-build/ninja-python-distributions/master/ninja-python-distributions-logo.png

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Ninja Python Distributions
 
 `Ninja <http://www.ninja-build.org>`_ is a small build system with a focus on speed.
 
-The latest Ninja python wheels provide `ninja 1.13.0 <https://ninja-build.org/manual.html>`_ executable
+The latest Ninja python wheels provide `ninja 1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1 <https://ninja-build.org/manual.html>`_ executable
 and `ninja_syntax.py` for generating `.ninja` files.
 
 .. image:: https://raw.githubusercontent.com/scikit-build/ninja-python-distributions/master/ninja-python-distributions-logo.png

--- a/docs/update_ninja_version.rst
+++ b/docs/update_ninja_version.rst
@@ -7,7 +7,7 @@ Updating the Ninja version
 A developer should use the following steps to update the version ``X.Y.Z``
 of Ninja associated with the current Ninja python distributions.
 
-Available Ninja archives can be found `here <https://github.com/ninja-build/ninja/releases>`_.
+Available Ninja archives can be found `here <https://github.com/Kitware/ninja/releases>`_.
 
 Nox prodedure
 -------------
@@ -29,17 +29,17 @@ Classic procedure:
 2. Execute `scripts/update_ninja_version.py` command line tool with the desired
    ``X.Y.Z`` Ninja version available for download. For example::
 
-    $ release=1.13.0
+    $ release=1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1
     $ python scripts/update_ninja_version.py ${release}
 
-    Collecting URLs and SHA256s from 'https://github.com/ninja-build/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1'
-    Downloading https://github.com/ninja-build/ninja/archive/v1.13.0.tar.gz
-    Downloading https://github.com/ninja-build/ninja/archive/v1.13.0.tar.gz - done
-    Downloading https://github.com/ninja-build/ninja/archive/v1.13.0.zip
-    Downloading https://github.com/ninja-build/ninja/archive/v1.13.0.zip - done
-    Collecting URLs and SHA256s from 'https://github.com/ninja-build/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1' - done
-    Updating 'NinjaUrls.cmake' with CMake version 1.13.0
-    Updating 'NinjaUrls.cmake' with CMake version 1.13.0 - done
+    Collecting URLs and SHA256s from 'https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1'
+    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.tar.gz
+    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.tar.gz - done
+    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.zip
+    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.zip - done
+    Collecting URLs and SHA256s from 'https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1' - done
+    Updating 'NinjaUrls.cmake' with CMake version 1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1
+    Updating 'NinjaUrls.cmake' with CMake version 1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1 - done
     Updating README.rst
     Updating README.rst - done
     Updating docs/update_ninja_version.rst
@@ -51,7 +51,7 @@ Classic procedure:
 3. Create a topic named `update-to-ninja-X.Y.Z` and commit the changes.
    For example::
 
-    release=1.13.0
+    release=1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1
     git checkout -b update-to-ninja-${release}
     git add NinjaUrls.cmake README.rst docs/update_ninja_version.rst tests/test_ninja.py
     git commit -m "Update to Ninja ${release}"

--- a/docs/update_ninja_version.rst
+++ b/docs/update_ninja_version.rst
@@ -29,17 +29,17 @@ Classic procedure:
 2. Execute `scripts/update_ninja_version.py` command line tool with the desired
    ``X.Y.Z`` Ninja version available for download. For example::
 
-    $ release=1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1
+    $ release=1.13.0.gd74ef.kitware.jobserver-pipe-1
     $ python scripts/update_ninja_version.py ${release}
 
     Collecting URLs and SHA256s from 'https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1'
-    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.tar.gz
-    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.tar.gz - done
-    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.zip
-    Downloading https://github.com/Kitware/ninja/archive/v1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1.zip - done
+    Downloading https://github.com/Kitware/ninja/archive/v1.13.0.gd74ef.kitware.jobserver-pipe-1.tar.gz
+    Downloading https://github.com/Kitware/ninja/archive/v1.13.0.gd74ef.kitware.jobserver-pipe-1.tar.gz - done
+    Downloading https://github.com/Kitware/ninja/archive/v1.13.0.gd74ef.kitware.jobserver-pipe-1.zip
+    Downloading https://github.com/Kitware/ninja/archive/v1.13.0.gd74ef.kitware.jobserver-pipe-1.zip - done
     Collecting URLs and SHA256s from 'https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1' - done
-    Updating 'NinjaUrls.cmake' with CMake version 1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1
-    Updating 'NinjaUrls.cmake' with CMake version 1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1 - done
+    Updating 'NinjaUrls.cmake' with CMake version 1.13.0.gd74ef.kitware.jobserver-pipe-1
+    Updating 'NinjaUrls.cmake' with CMake version 1.13.0.gd74ef.kitware.jobserver-pipe-1 - done
     Updating README.rst
     Updating README.rst - done
     Updating docs/update_ninja_version.rst
@@ -51,7 +51,7 @@ Classic procedure:
 3. Create a topic named `update-to-ninja-X.Y.Z` and commit the changes.
    For example::
 
-    release=1.12.1.ge64ce.kitware.jobserver-1.msvcdepfile-1
+    release=1.13.0.gd74ef.kitware.jobserver-pipe-1
     git checkout -b update-to-ninja-${release}
     git add NinjaUrls.cmake README.rst docs/update_ninja_version.rst tests/test_ninja.py
     git commit -m "Update to Ninja ${release}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,11 @@ select = "*_s390x"
 inherit.config-settings = "append"
 config-settings = {"cmake.define.TEST_OPTS" = "--gtest_filter=-DepsLogTest.MalformedDepsLog"}
 
+# Doesn't account for platform in 1.13.0 https://github.com/scikit-build/ninja-python-distributions/pull/305#issuecomment-3146299285
+[[tool.cibuildwheel.overrides]]
+select = "*-win*"
+inherit.config-settings = "append"
+config-settings = {"cmake.define.TEST_OPTS" = "--gtest_filter=-Jobserver.ParseNativeMakeFlagsValue"}
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ select = "*_s390x"
 inherit.config-settings = "append"
 config-settings = {"cmake.define.TEST_OPTS" = "--gtest_filter=-DepsLogTest.MalformedDepsLog"}
 
-# Doesn't account for platform in 1.13.0 https://github.com/scikit-build/ninja-python-distributions/pull/305#issuecomment-3146299285
+# Doesn't account for platform in 1.13.0 https://github.com/Kitware/ninja/pull/3
 [[tool.cibuildwheel.overrides]]
 select = "*-win*"
 inherit.config-settings = "append"

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -12,7 +12,6 @@ import ninja
 
 from . import push_argv
 
-
 MSVC_DEPFILE = ".msvcdepfile-1" if sys.platform.startswith("win32") else ""
 
 def _run(program, args):

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -13,6 +13,8 @@ import ninja
 from . import push_argv
 
 
+MSVC_DEPFILE = ".msvcdepfile-1" if sys.platform.startswith("win32") else ""
+
 def _run(program, args):
     func = getattr(ninja, program)
     args = [f"{program}.py", *args]
@@ -36,13 +38,13 @@ def test_ninja_module():
 
 
 def test_ninja_package():
-    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
+    expected_version = f"1.12.1.git.kitware.jobserver-1{MSVC_DEPFILE}"
     output = subprocess.check_output([sys.executable, "-m", "ninja", "--version"]).decode("ascii")
     assert output.splitlines()[0] == expected_version
 
 
 def test_ninja_script():
-    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
+    expected_version = f"1.12.1.git.kitware.jobserver-1{MSVC_DEPFILE}"
     scripts = _get_scripts()
     assert len(scripts) == 1
     assert scripts[0].stem == "ninja"

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -36,13 +36,13 @@ def test_ninja_module():
 
 
 def test_ninja_package():
-    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
+    expected_version = "1.13.0.git.kitware.jobserver-pipe-1"
     output = subprocess.check_output([sys.executable, "-m", "ninja", "--version"]).decode("ascii")
     assert output.splitlines()[0] == expected_version
 
 
 def test_ninja_script():
-    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
+    expected_version = "1.13.0.git.kitware.jobserver-pipe-1"
     scripts = _get_scripts()
     assert len(scripts) == 1
     assert scripts[0].stem == "ninja"

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -13,8 +13,6 @@ import ninja
 from . import push_argv
 
 
-MSVC_DEPFILE = ".msvcdepfile-1" if sys.platform.startswith("win32") else ""
-
 def _run(program, args):
     func = getattr(ninja, program)
     args = [f"{program}.py", *args]
@@ -38,13 +36,13 @@ def test_ninja_module():
 
 
 def test_ninja_package():
-    expected_version = f"1.12.1.git.kitware.jobserver-1{MSVC_DEPFILE}"
+    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
     output = subprocess.check_output([sys.executable, "-m", "ninja", "--version"]).decode("ascii")
     assert output.splitlines()[0] == expected_version
 
 
 def test_ninja_script():
-    expected_version = f"1.12.1.git.kitware.jobserver-1{MSVC_DEPFILE}"
+    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
     scripts = _get_scripts()
     assert len(scripts) == 1
     assert scripts[0].stem == "ninja"

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -12,6 +12,7 @@ import ninja
 
 from . import push_argv
 
+
 MSVC_DEPFILE = ".msvcdepfile-1" if sys.platform.startswith("win32") else ""
 
 def _run(program, args):

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -36,13 +36,13 @@ def test_ninja_module():
 
 
 def test_ninja_package():
-    expected_version = "1.13.0"
+    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
     output = subprocess.check_output([sys.executable, "-m", "ninja", "--version"]).decode("ascii")
     assert output.splitlines()[0] == expected_version
 
 
 def test_ninja_script():
-    expected_version = "1.13.0"
+    expected_version = "1.12.1.git.kitware.jobserver-1.msvcdepfile-1"
     scripts = _get_scripts()
     assert len(scripts) == 1
     assert scripts[0].stem == "ninja"


### PR DESCRIPTION
Ran `nox -s bump -- --upstream-repository Kitware/ninja`.

The Kitware fork adds the following feature compared to upstream:
- `make-4.3-jobserver-1`: Based on [this release](https://github.com/digit-google/ninja/releases/tag/JOBSERVER-with-pipe-support), which includes pipe-based jobserver support for Make 4.3 and was conveniently created by the same developer who upstreamed jobserver support