### PR TITLE
chore(deps): bump pypa/cibuildwheel from 2.23 to 3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,11 @@ jobs:
             arch: "s390x"
           - os: ubuntu-24.04-arm
             arch: "armv7l"
-          - os: windows-2019
-            arch: "AMD64"
           - os: windows-2022
+            arch: "AMD64"
+          - os: windows-11-arm
             arch: "ARM64"
-          - os: windows-2019
+          - os: windows-2022
             arch: "x86"
           - os: macos-13
             arch: "universal2"
@@ -76,7 +76,7 @@ jobs:
           enable-cache: false
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.1
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,27 +85,30 @@ replacement = ""
 
 
 [tool.cibuildwheel]
+archs = ["auto64", "auto32"]
 build = "cp39-*"
 build-frontend = "build[uv]"
 build-verbosity = 1
 test-groups = "test"
 test-command = "pytest {project}/tests"
-test-skip = ["*-win_arm64", "*-macosx_universal2:arm64"]
+test-skip = ["*-macosx_universal2:arm64"]
 environment = { NINJA_PYTHON_DIST_ALLOW_NINJA_DEP = "1" }
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
-musllinux-x86_64-image = "musllinux_1_1"
-musllinux-i686-image = "musllinux_1_1"
-musllinux-aarch64-image = "musllinux_1_1"
-musllinux-ppc64le-image = "musllinux_1_1"
-musllinux-s390x-image = "musllinux_1_1"
+manylinux-x86_64-image = "quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177"
+manylinux-i686-image = "quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177"
+manylinux-aarch64-image = "manylinux2014"
+manylinux-ppc64le-image = "manylinux2014"
+manylinux-s390x-image = "manylinux2014"
+manylinux-armv7l-image = "manylinux_2_31"
+musllinux-x86_64-image = "quay.io/pypa/musllinux_1_1_x86_64:2024.10.26-1"
+musllinux-i686-image = "quay.io/pypa/musllinux_1_1_i686:2024.10.26-1"
+musllinux-aarch64-image = "quay.io/pypa/musllinux_1_1_aarch64:2024.10.26-1"
+musllinux-ppc64le-image = "quay.io/pypa/musllinux_1_1_ppc64le:2024.10.26-1"
+musllinux-s390x-image = "quay.io/pypa/musllinux_1_1_s390x:2024.10.26-1"
 musllinux-armv7l-image = "musllinux_1_2"
 
 [tool.cibuildwheel.config-settings]
 "cmake.define.RUN_NINJA_TEST" = "ON"
-
-[[tool.cibuildwheel.overrides]]
-select = ["*-win_arm64",]
-config-settings."cmake.define.RUN_NINJA_TEST" = "OFF"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macos*"
@@ -114,8 +117,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.9" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-manylinux_{x86_64,i686}"
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
+before-build = "python -m pip install 'pip==25.1.1'"
 build-frontend = "pip"
 inherit.environment = "append"
 environment = { LDFLAGS = "-static-libstdc++" }
@@ -128,8 +130,8 @@ inherit.environment = "append"
 environment = { LDFLAGS = "-static-libstdc++ -static-libgcc" }
 
 [[tool.cibuildwheel.overrides]]
-select = "*-musllinux_s390x"
-build-frontend = "pip"
+select = "*-musllinux_{ppc64le,s390x}"
+build-frontend = "pip"  # uv not available
 inherit.test-command = "prepend"
 inherit.config-settings = "append"
 test-command = "pip check"


### PR DESCRIPTION
Update to cibuildwheel 3.1 with the same targets perimeter.
`windows-2019` has been retired so switch to `windows-2022`.
We can use the `windows-11-arm` which enables testing on Windows ARM64.