### PR TITLE
break: drop Python 3.7, manylinux2010 & musllinux_1_1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,11 +129,11 @@ jobs:
   test_sdist:
     name: Test SDist with python ${{ matrix.python }}
     needs: [build_sdist]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.12"]
+        python: ["3.8", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -147,7 +147,6 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: false
-          version: "0.6.17"
 
       - name: Setup environment
         run: |

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Python Version Support
 ----------------------
 
 Versions after 1.11.1.1 no longer support Python 2-3.6, and require manylinux2010+ on linux.
+Versions after 1.13 no longer support Python 3.7, and require manylinux2014+/musllinux_1_2+ on linux.
 
 License
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/scikit-build/ninja-python-distributions/issues"
@@ -94,18 +94,18 @@ test-command = "pytest {project}/tests"
 test-skip = ["*-macosx_universal2:arm64"]
 environment = { NINJA_PYTHON_DIST_ALLOW_NINJA_DEP = "1" }
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
-manylinux-x86_64-image = "quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177"
-manylinux-i686-image = "quay.io/pypa/manylinux2010_i686:2022-08-05-4535177"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
 manylinux-armv7l-image = "manylinux_2_31"
 manylinux-riscv64-image = "manylinux_2_39"
-musllinux-x86_64-image = "quay.io/pypa/musllinux_1_1_x86_64:2024.10.26-1"
-musllinux-i686-image = "quay.io/pypa/musllinux_1_1_i686:2024.10.26-1"
-musllinux-aarch64-image = "quay.io/pypa/musllinux_1_1_aarch64:2024.10.26-1"
-musllinux-ppc64le-image = "quay.io/pypa/musllinux_1_1_ppc64le:2024.10.26-1"
-musllinux-s390x-image = "quay.io/pypa/musllinux_1_1_s390x:2024.10.26-1"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-i686-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
+musllinux-ppc64le-image = "musllinux_1_2"
+musllinux-s390x-image = "musllinux_1_2"
 musllinux-armv7l-image = "musllinux_1_2"
 musllinux-riscv64-image = "musllinux_1_2"
 
@@ -116,15 +116,6 @@ musllinux-riscv64-image = "musllinux_1_2"
 select = "*-macos*"
 inherit.environment = "append"
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.9" }
-
-[[tool.cibuildwheel.overrides]]
-select = "*-manylinux_{x86_64,i686}"
-before-build = "python -m pip install 'pip==25.1.1'"
-build-frontend = "pip"
-inherit.environment = "append"
-environment = { LDFLAGS = "-static-libstdc++" }
-inherit.test-command = "prepend"
-test-command = "pip check"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux_*"


### PR DESCRIPTION
backport work done in #301 now that cibuildwheel has been updated in master

@henryiii said
> @mayeut, @jcfr, what should we do here:
> Move to using manylinux_2_28 (cibuildwheel default)
> Move to using manylinux_2014
> Keep manylinux_2010 (fully specify)
> And
> Move to using musllinux_1_2 (cibuildwheel default)
> Keep musllinux_1_1 (fully specify)
> And
> Move to requiring Python 3.8+ (might be best if increasing manylinux?)
> Keep 3.7+ (we don't actually depend on Python at all, but 3.7 users might need older platforms)
> ?
> (I think I like 2014 + 1_2 + 3.8+, though a step more modern is 2_28 + 1_2 + 3.8+ and a step less modern is 2014 + 1_2 + 3.7+ )
> And should we do this for 1.13 or after?

@mayeut replied
> I think I like 2014 + 1_2 + 3.8+ too. It's probably a bit too soon to move to 2_28. While python_requires ensures that the previous version will be installed on 3.7, this is not the case for the manylinux/musllinux targets. The move of the default in cibuildwheel will likely help see a change in the target builds (and numpy moving to 2_28 might move things towards seeing less & less manylinux2014 wheels being built) but my feeling is that it's too soon.
> IMHO, this can be done in the next minor version (depending on #305)