### PR TITLE
feat: add riscv64 linux wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
             arch: "ppc64le"
           - os: ubuntu-24.04
             arch: "s390x"
+          - os: ubuntu-24.04
+            arch: "riscv64"
           - os: ubuntu-24.04-arm
             arch: "armv7l"
           - os: windows-2022

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,14 @@ manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
 manylinux-armv7l-image = "manylinux_2_31"
+manylinux-riscv64-image = "manylinux_2_39"
 musllinux-x86_64-image = "quay.io/pypa/musllinux_1_1_x86_64:2024.10.26-1"
 musllinux-i686-image = "quay.io/pypa/musllinux_1_1_i686:2024.10.26-1"
 musllinux-aarch64-image = "quay.io/pypa/musllinux_1_1_aarch64:2024.10.26-1"
 musllinux-ppc64le-image = "quay.io/pypa/musllinux_1_1_ppc64le:2024.10.26-1"
 musllinux-s390x-image = "quay.io/pypa/musllinux_1_1_s390x:2024.10.26-1"
 musllinux-armv7l-image = "musllinux_1_2"
+musllinux-riscv64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.config-settings]
 "cmake.define.RUN_NINJA_TEST" = "ON"
@@ -130,7 +132,7 @@ inherit.environment = "append"
 environment = { LDFLAGS = "-static-libstdc++ -static-libgcc" }
 
 [[tool.cibuildwheel.overrides]]
-select = "*-musllinux_{ppc64le,s390x}"
+select = "*-musllinux_{ppc64le,s390x,riscv64}"
 build-frontend = "pip"  # uv not available
 inherit.test-command = "prepend"
 inherit.config-settings = "append"


### PR DESCRIPTION
This PR adds riscv64 linux wheels now that they can be uploaded to PyPI.